### PR TITLE
Fix gym→gymnasium compatibility for SB3 v2+ environments

### DIFF
--- a/common/buffers.py
+++ b/common/buffers.py
@@ -3,7 +3,7 @@ from typing import Generator, NamedTuple, Optional, Union, Callable, Tuple
 
 import numpy as np
 import torch as th
-from gym import spaces
+from gymnasium import spaces
 from stable_baselines3.common.buffers import DictRolloutBuffer, RolloutBuffer
 from stable_baselines3.common.type_aliases import TensorDict
 from stable_baselines3.common.vec_env import VecNormalize

--- a/common/distributions.py
+++ b/common/distributions.py
@@ -3,7 +3,7 @@ from typing import List, Optional, Tuple, TypeVar
 
 import numpy as np
 import torch as th
-from gym import spaces
+from gymnasium import spaces
 from stable_baselines3.common.distributions import Distribution
 from torch import nn
 from torch.distributions import Categorical

--- a/common/evaluation.py
+++ b/common/evaluation.py
@@ -1,7 +1,7 @@
 import warnings
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
-import gym
+import gymnasium as gym
 import numpy as np
 from stable_baselines3.common.monitor import Monitor
 from stable_baselines3.common.vec_env import DummyVecEnv, VecEnv, VecMonitor, is_vecenv_wrapped

--- a/common/policies.py
+++ b/common/policies.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List, Optional, Tuple, Type, Union
 
 import numpy as np
 import torch as th
-from gym import spaces
+from gymnasium import spaces
 from stable_baselines3.common.distributions import Distribution
 from stable_baselines3.common.policies import ActorCriticPolicy
 from stable_baselines3.common.torch_layers import (

--- a/ppo_mask_recurrent.py
+++ b/ppo_mask_recurrent.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, Optional, Tuple, Type, TypeVar, Union
 
 import numpy as np
 import torch as th
-from gym import spaces
+from gymnasium import spaces
 from stable_baselines3.common import utils
 
 from stable_baselines3.common.buffers import RolloutBuffer


### PR DESCRIPTION
Replace all `from gym import spaces` / `import gym` with `from gymnasium import spaces` / `import gymnasium as gym` across 5 files. gym.spaces and gymnasium.spaces are different classes — isinstance checks were failing silently for gymnasium-based envs, breaking action masking and distribution selection.